### PR TITLE
Added two API calls, plus .env file.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+FAIRSHARING_API_KEY="your_key_goes_here"
+FAIRSHARING_API_URL="https://api.fairsharing.org/graphql/"

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 out
 .idea
+.env

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'minitest'
 gem 'rerun'
 gem 'httparty'
 gem 'rake'
+gem 'dotenv'
 
 # Somewhat old, but should do the trick...
 gem 'simple_doi', github: 'UMNLibraries/simpledoi-ruby'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,6 +13,7 @@ GEM
     bigdecimal (4.1.0)
     csv (3.3.5)
     curb (1.2.2)
+    dotenv (3.2.0)
     drb (2.2.3)
     ffi (1.17.4)
     ffi (1.17.4-x86_64-linux-gnu)
@@ -81,6 +82,7 @@ PLATFORMS
 
 DEPENDENCIES
   curb
+  dotenv
   httparty
   minitest
   puma
@@ -97,6 +99,7 @@ CHECKSUMS
   bigdecimal (4.1.0) sha256=6dc07767aa3dc456ccd48e7ae70a07b474e9afd7c5bc576f80bd6da5c8dd6cae
   csv (3.3.5) sha256=6e5134ac3383ef728b7f02725d9872934f523cb40b961479f69cf3afa6c8e73f
   curb (1.2.2) sha256=64ebccac50bd682bedb58a8b5456295c46a4eed67e84111f2d79041e1b6bacc7
+  dotenv (3.2.0) sha256=e375b83121ea7ca4ce20f214740076129ab8514cd81378161f11c03853fe619d
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
   ffi (1.17.4) sha256=bcd1642e06f0d16fc9e09ac6d49c3a7298b9789bcb58127302f934e437d60acf
   ffi (1.17.4-x86_64-linux-gnu) sha256=9d3db14c2eae074b382fa9c083fe95aec6e0a1451da249eab096c34002bc752d

--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ There are .ruby-version and .ruby-gemset files in the root directory, so
 
 Run `gem install bundler` and `bundle install` to install the required gems.
 
+`cp .env.example .env` and edit the value for your API key. You probably won't need
+to change the value for the FAIRsharing API URL unless you're running a local instance 
+of FAIRsharing.
+
 Run the application with `rerun 'rackup'`.
 
 ### Development
@@ -45,6 +49,11 @@ bundle exec irb
 > get_doi_metadata('https://doi.org/10.25504/FAIRsharing.7g1bzj')
 ```
 
+### Unit Tests
+
+These can be run with `bundle exec rake test`.
+
 ## Deployment
+
 
 Probably a Systemd service for fair_tests.rb, with an Nginx proxy (TODO).

--- a/fair_tests.rb
+++ b/fair_tests.rb
@@ -1,5 +1,6 @@
 require 'sinatra'
 require 'sinatra/json'
+require 'dotenv/load'
 
 class FairTests < Sinatra::Base
 

--- a/lib/test_utils.rb
+++ b/lib/test_utils.rb
@@ -2,6 +2,7 @@ require 'httparty'
 require 'simple_doi'
 require 'json'
 require 'nokogiri'
+require 'dotenv/load'
 
 # Utility functions common to all FAIR tests.
 module TestUtils
@@ -147,6 +148,148 @@ module TestUtils
     end
   rescue Net::OpenTimeout, Net::ReadTimeout
     nil
+  end
+
+
+  # This method will prepare a text string for getting a record from FAIRsharing, then fetch the record.
+  def obtain_record_from_text(text_record)
+    # Only accept FAIRsharing URLs
+    if text_record.blank? || !(text_record.include?('https://doi.org/10.25504') ||
+      text_record.include?('https://fairsharing.org/10.25504') ||
+      text_record.include?('fairsharing.org'))
+      return nil
+    end
+
+    record = nil
+    text_record = text_record.chop if text_record.end_with?('/')
+
+    if text_record.include?('10.25504') || text_record.include?('//fairsharing.org/FAIRsharing')
+      v = text_record.split('/')
+      record = get_fairsharing_record("10.25504/#{v[-1]}")
+    elsif text_record.include?('https://fairsharing.org') || text_record.include?('https://preview.fairsharing.org')
+      v = text_record.split('/')
+      record = get_fairsharing_record(v[-1].to_i)
+    end
+    record
+  end
+
+  # This will get a record from the FAIRsharing database via the API.
+  # TODO: Currently the data are very extensive, but we may need only metadata and perhaps relations.
+  def get_fairsharing_record(id)
+    headers = {
+      'Content-Type' => 'application/json' ,
+      'Accept' => 'application/json',
+      'X-GraphQL-Key' => ENV['FAIRSHARING_API_KEY']
+    }
+    query_string = %Q{
+      query {
+        fairsharingRecord(id: "#{id}"){
+          name
+          id
+          subjects { id label }
+          registry
+          type
+          metadata
+          exhaustiveLicences
+          domains { id label }
+          taxonomies { id label }
+          userDefinedTags { id label }
+          organisations { id name }
+          organisationLinks {
+            id
+            relation
+            fairsharingRecord { id }
+            organisation { id name }
+            grant {id name}
+            isLead
+          }
+          grants { id name }
+          publications { id title }
+          licences { id name }
+          licenceLinks {
+            relation
+            licence { id name }
+          }
+          description
+          createdAt
+          updatedAt
+          recordAssociations {
+            recordAssocLabel
+            recordAssocLabelId
+            linkedRecord {
+              name
+              id
+              registry
+              type
+            }
+          }
+          reverseRecordAssociations {
+            recordAssocLabel
+            recordAssocLabelId
+            fairsharingRecord {
+              name
+              id
+              registry
+              type
+            }
+          }
+         objectTypes {
+          id
+         }
+         format
+        }
+      }
+    }
+
+    response = HTTParty.post(ENV['FAIRSHARING_API_URL'],
+                             body: { query: query_string }.to_json,
+                             headers: headers
+    )
+
+
+    if response.code == 200
+      JSON.parse(response.body)['data']['fairsharingRecord']
+    else
+      {
+        message: "Error getting record from FAIRsharing API: #{response.code}, #{response.message}",
+      }
+    end
+  end
+
+  #...and this one is for calling the find_matching_regex method on the FAIRsharing API.
+  # It returns a hash with matches (the original regex matches) and records; these latter
+  # are the full data of each record in the matches hash.
+  def find_by_regex(url)
+    headers = {
+      'Content-Type' => 'application/json' ,
+      'Accept' => 'application/json',
+      'X-GraphQL-Key' => ENV['FAIRSHARING_API_KEY']
+    }
+    query_string = %Q{
+      query {
+        regex(term: "#{url}", secondary: true){
+          records {
+            name
+            id
+            metadata
+          }
+          matches
+        }
+      }
+    }
+
+    response = HTTParty.post(ENV['FAIRSHARING_API_URL'],
+                             body: { query: query_string }.to_json,
+                             headers: headers
+    )
+
+    if response.code == 200
+      JSON.parse(response.body)['data']['regex']
+    else
+      {
+        message: "Error getting record from FAIRsharing API: #{response.code}, #{response.message}",
+      }
+    end
   end
 
 end


### PR DESCRIPTION
This adds two queries. The first simply gets a fairsharing_record, and the second gets all records whose regexes match the pattern sent.


These can be tried out as follows:

```
bundle exec irb
require_relative 'lib/test_utils'; include TestUtils
records = find_by_regex('10.123/FAIRsharing.123456')
r = get_fairsharing_record(1547)
```

A .env file with the correct API key and URL will be needed first. 