### PR TITLE
Addition of new harvester code. #47

### DIFF
--- a/lib/fair_test_utils.rb
+++ b/lib/fair_test_utils.rb
@@ -54,7 +54,7 @@ module FairTestUtils
     response
   end
 
-  def improved_content_negotiation(url)
+  def metadata_harvesting(url)
     json_headers = {
       'Accept' => 'application/json',
       'Content-Type' => 'application/json'

--- a/lib/fair_test_utils.rb
+++ b/lib/fair_test_utils.rb
@@ -64,7 +64,12 @@ module FairTestUtils
                              body: { resource_identifier: url }.to_json,
                              headers: json_headers
     )
-    response
+    body = response.body.to_s.strip
+    return nil if body.empty?
+
+    JSON.parse(body)
+  rescue JSON::ParserError
+    nil
   end
 
   # Parse the data structure returned by metadata harvesting and look for particular keys.

--- a/lib/fair_test_utils.rb
+++ b/lib/fair_test_utils.rb
@@ -54,6 +54,19 @@ module FairTestUtils
     response
   end
 
+  def improved_content_negotiation(url)
+    json_headers = {
+      'Accept' => 'application/json',
+      'Content-Type' => 'application/json'
+    }
+    champion_url = 'https://tools.ostrails.eu/champion/harvest_only'
+    response = HTTParty.post(champion_url,
+                             body: { resource_identifier: url }.to_json,
+                             headers: json_headers
+    )
+    response
+  end
+
   def content_negotiation(url)
     return {} if url.nil? || url.empty?
 

--- a/lib/fair_test_utils.rb
+++ b/lib/fair_test_utils.rb
@@ -64,34 +64,6 @@ module FairTestUtils
     end
   end
 
-  def content_negotiation(url)
-    return {} if url.nil? || url.empty?
-
-    # TODO: This assumes that there's JSON data available.
-    # TODO: Better content negotation needed (Mark's tool?)
-    json_headers = {
-      'Accept' => 'application/json',
-      'Content-Type' => 'application/json'
-    }
-    jsonld_headers = {
-      'Accept' => 'application/ld+json',
-      'Content-Type' => 'application/ld+json'
-    }
-
-    # Try LD+JSON first
-    response = HTTParty.get(url, headers: jsonld_headers)
-    body = JSON.parse(response.body)
-
-    unless body && body['@context'] == 'https://schema.org'
-      response = HTTParty.get(url, headers: json_headers)
-      body = JSON.parse(response.body)
-    end
-    #status = response.code,
-    #message = response.message
-
-    body
-  end
-
   # TODO:
   # This should be able to get JSON-formatted data from a DOI.
   # It may be that we replace this at a later date with Mark's system, or
@@ -340,38 +312,6 @@ module FairTestUtils
         message: "Error getting record from FAIRsharing API: #{response.code}, #{response.message}",
       }
     end
-  end
-
-  # The purpose of this function is to flip out and recursively traverse a hash in order to find any keys where
-  # the value is a non-empty array.
-  def find_keys_with_non_empty_values(obj, results = [], path = [])
-    case obj
-    when Hash
-      obj.each do |key, value|
-        current_path = path + [key]
-
-        # Check if the value is a non-empty array
-        if value.is_a?(Array) && !value.empty?
-          results << current_path
-        end
-
-        if value.is_a?(String) && !value.empty?
-          results << current_path
-        end
-
-        # Recurse into nested structures
-        find_keys_with_non_empty_values(value, results, current_path)
-      end
-
-    when Array
-      obj.each_with_index do |item, index|
-        find_keys_with_non_empty_values(item, results, path + [index])
-      end
-    else
-      return []
-    end
-
-    results.flatten
   end
 
   # Recursively traverse a parsed JSON-LD structure and return prov:value's @value.

--- a/lib/fair_test_utils.rb
+++ b/lib/fair_test_utils.rb
@@ -9,51 +9,6 @@ require 'uri'
 # Utility functions common to all FAIR tests.
 module FairTestUtils
 
-  def fair_test_response_basics(test_data)
-    response = {}
-    response['@context'] = "https://w3id.org/ftr/context"
-    response['@id'] = "urn:fairsharing:#{SecureRandom.uuid}"
-    response['@type'] = "https://w3id.org/ftr#TestResult"
-    response[:identifier] = response['@id']
-    response[:title] = test_data[:test_title]
-    response[:license] = {
-      '@id': 'https://fairsharing.org/licence'
-    }
-    response[:completion] = {
-      '@value': 100
-    }
-    response[:assessmentTarget] = {
-      '@id': test_data[:url_record]
-    }
-    response[:outputFromTest] = {
-      '@id': test_data[:test_id],
-      '@type': 'Test'
-    }
-    response[:generatedAtTime] = {
-      '@type': 'http://www.w3.org/2001/XMLSchema#date',
-      '@value': DateTime.now.to_s
-    }
-    response[:wasGeneratedBy] = {
-      '@type': 'TestExecutionActivity',
-      used: {
-        '@id': test_data[:url_record]
-      },
-      wasAssociatedWith: {
-        '@id': test_data[:test_id],
-        identifier: test_data[:test_id],
-        title: test_data[:test_title_short],
-        description: test_data[:description],
-        endpointDescription: {
-          '@id': test_data[:endpointDescription]
-        },
-        endpointURL: {
-          '@id': test_data[:endpointURL]
-        }
-      }
-    }
-    response
-  end
-
   def metadata_harvesting(url)
     json_headers = {
       'Accept' => 'application/json',

--- a/lib/fair_test_utils.rb
+++ b/lib/fair_test_utils.rb
@@ -67,6 +67,44 @@ module FairTestUtils
     response
   end
 
+  # Parse the data structure returned by metadata harvesting and look for particular keys.
+  # Usage: has_matching_key_with_value?(data, %w[publisher publish])
+  def has_matching_key_with_value?(obj, patterns)
+    case obj
+    when Hash
+      obj.any? do |key, value|
+        (
+          patterns.any? { |p| key.to_s.downcase.include?(p.downcase) } &&
+            contains_meaningful_value?(value)
+        ) || has_matching_key_with_value?(value, patterns)
+      end
+
+    when Array
+      obj.any? { |item| has_matching_key_with_value?(item, patterns) }
+
+    else
+      false
+    end
+  end
+
+  # Necessary for the above function:
+  # This code is to return true if a value from the data structure is not nil, empty etc.
+  def contains_meaningful_value?(value)
+    case value
+    when nil
+      false
+    when String
+      !value.strip.empty?
+    when Numeric
+      value != 0
+    when Array, Hash
+      !value.empty?
+    else
+      true
+    end
+  end
+
+
   def content_negotiation(url)
     return {} if url.nil? || url.empty?
 

--- a/lib/fair_tests/ft_f2_m_discoveryfields.rb
+++ b/lib/fair_tests/ft_f2_m_discoveryfields.rb
@@ -48,7 +48,7 @@ module FtF2MDiscoveryfields
         else
           # If DOI metadata fails, resolve DOI and test the resolved target.
           real_url = resolve_doi(original_url)
-          record = content_negotiation(real_url)
+          record = metadata_harvesting(real_url)
           if record && !record.empty?
             response = perform_ft_f2_m_discoveryfields(record, response)
             return response.createEvaluationResponse
@@ -57,14 +57,14 @@ module FtF2MDiscoveryfields
         return response.createEvaluationResponse
       else # Try content negotiation
         real_url = resolve_doi(original_url)
-        record = content_negotiation(real_url)
+        record = metadata_harvesting(real_url)
         if record && !record.empty?
           response = perform_ft_f2_m_discoveryfields(record, response)
           return response.createEvaluationResponse
         end
       end
     else # Try content negotiation
-      record = content_negotiation(url_record)
+      record = metadata_harvesting(url_record)
       if record && !record.empty?
         response = perform_ft_f2_m_discoveryfields(record, response)
         return response.createEvaluationResponse
@@ -76,24 +76,10 @@ module FtF2MDiscoveryfields
 
   # This method will perform the actual tests to avoid repetition above.
   def perform_ft_f2_m_discoveryfields(record, response)
-    pass = false
-    keys = find_keys_with_non_empty_values(record)
-    keys.each do |key|
-      if @@required_fields.to_s.include?(key)
-        response.score = 'pass'
-        response.comments << "The record contains at least one of the required fields: #{@@required_fields.join(', ')}."
-        pass = true
-      else
-        @@required_fields.each do |field|
-          if field.to_s.include?(key) || key.include?(field)
-            response.score = 'pass'
-            response.comments << "The record contains at least one of the required fields: #{@@required_fields.join(', ')}."
-            pass = true
-          end
-        end
-      end
-    end
-    unless pass
+    if has_matching_key_with_value?(record, @@required_fields)
+      response.score = 'pass'
+      response.comments << "The record contains at least one of the required fields: #{@@required_fields.join(', ')}."
+    else
       response.score = 'fail'
       response.comments << "The record does not contain at least one of the required fields: #{@@required_fields.join(', ')}."
     end

--- a/lib/fair_tests/ft_f2_m_discoverypublisher.rb
+++ b/lib/fair_tests/ft_f2_m_discoverypublisher.rb
@@ -8,9 +8,9 @@ module FtF2MDiscoverypublisher
   def ft_f2_m_discoverypublisher(url_record)
     # 1. If a DOI, get metadata from Datacite.
     # 2. Run tests.
-    # 3. If fail, try content negotation.
+    # 3. If fail, try metadata harvesting.
     # 4. Run tests again.
-    # 5. If not DOI, try content negotation.
+    # 5. If not DOI, try metadata harvesting.
 
     # SimpleDOI may mutate the passed string, so keep an immutable copy.
     original_url = url_record&.dup
@@ -47,23 +47,26 @@ module FtF2MDiscoverypublisher
         else
           # If DOI metadata fails, resolve DOI and test the resolved target.
           real_url = resolve_doi(original_url)
-          record = content_negotiation(real_url)
+          record = metadata_harvesting(real_url)
           if record && !record.empty?
-            return perform_ft_f2_m_discoverypublisher(record, response).createEvaluationResponse
+            response = perform_ft_f2_m_discoverypublisher(record, response)
+            return response.createEvaluationResponse
           end
         end
         return response.createEvaluationResponse
-      else # Try content negotiation
+      else # Try metadata harvesting
         real_url = resolve_doi(original_url)
-        record = content_negotiation(real_url)
+        record = metadata_harvesting(real_url)
         if record && !record.empty?
-          return perform_ft_f2_m_discoverypublisher(record, response).createEvaluationResponse
+          response = perform_ft_f2_m_discoverypublisher(record, response)
+          return response.createEvaluationResponse
         end
       end
-    else # Try content negotiation
-      record = content_negotiation(url_record)
+    else # Try metadata harvesting
+      record = metadata_harvesting(url_record)
       if record && !record.empty?
-        return perform_ft_f2_m_discoverypublisher(record, response).createEvaluationResponse
+        response = perform_ft_f2_m_discoverypublisher(record, response)
+        return response.createEvaluationResponse
       end
     end
 
@@ -72,28 +75,13 @@ module FtF2MDiscoverypublisher
 
   # This method will perform the actual tests to avoid repetition above.
   def perform_ft_f2_m_discoverypublisher(record, response)
-    pass = false
-    keys = find_keys_with_non_empty_values(record)
-    keys.each do |key|
-      if @@required_fields.to_s.include?(key)
-        response.score = 'pass'
-        response.comments << "The record contains at least one of the required fields: #{@@required_fields.join(', ')}."
-        pass = true
-      else
-        @@required_fields.each do |field|
-          if field.to_s.include?(key) || key.include?(field)
-            response.score = 'pass'
-            response.comments << "The record contains at least one of the required fields: #{@@required_fields.join(', ')}."
-            pass = true
-          end
-        end
-      end
-    end
-    unless pass
+    if has_matching_key_with_value?(record, @@required_fields)
+      response.score = 'pass'
+      response.comments << "The record contains at least one of the required fields: #{@@required_fields.join(', ')}."
+    else
       response.score = 'fail'
       response.comments << "The record does not contain at least one of the required fields: #{@@required_fields.join(', ')}."
     end
-
 
     response
   end

--- a/lib/fair_tests/ft_f2_m_discoverytags.rb
+++ b/lib/fair_tests/ft_f2_m_discoverytags.rb
@@ -8,9 +8,9 @@ module FtF2MDiscoverytags
   def ft_f2_m_discoverytags(url_record)
     # 1. If a DOI, get metadata from Datacite.
     # 2. Run tests.
-    # 3. If fail, try content negotation.
+    # 3. If fail, try metadata harvesting.
     # 4. Run tests again.
-    # 5. If not DOI, try content negotation.
+    # 5. If not DOI, try metadata harvesting.
 
     # SimpleDOI may mutate the passed string, so keep an immutable copy.
     original_url = url_record&.dup
@@ -48,23 +48,26 @@ module FtF2MDiscoverytags
         else
           # If DOI metadata fails, resolve DOI and test the resolved target.
           real_url = resolve_doi(original_url)
-          record = content_negotiation(real_url)
+          record = metadata_harvesting(real_url)
           if record && !record.empty?
-            return perform_ft_f2_m_discoverytags(record, response).createEvaluationResponse
+            response = perform_ft_f2_m_discoverytags(record, response)
+            return response.createEvaluationResponse
           end
         end
         return response.createEvaluationResponse
-      else # Try content negotiation
+      else # Try metadata harvesting
         real_url = resolve_doi(original_url)
-        record = content_negotiation(real_url)
+        record = metadata_harvesting(real_url)
         if record && !record.empty?
-          return perform_ft_f2_m_discoverytags(record, response).createEvaluationResponse
+          response = perform_ft_f2_m_discoverytags(record, response)
+          return response.createEvaluationResponse
         end
       end
-    else # Try content negotiation
-      record = content_negotiation(url_record)
+    else # Try metadata harvesting
+      record = metadata_harvesting(url_record)
       if record && !record.empty?
-        return perform_ft_f2_m_discoverytags(record, response).createEvaluationResponse
+        response = perform_ft_f2_m_discoverytags(record, response)
+        return response.createEvaluationResponse
       end
     end
 
@@ -73,24 +76,10 @@ module FtF2MDiscoverytags
 
   # This method will perform the actual tests to avoid repetition above.
   def perform_ft_f2_m_discoverytags(record, response)
-    pass = false
-    keys = find_keys_with_non_empty_values(record)
-    keys.each do |key|
-      if @@required_fields.include?(key)
-        response.score = 'pass'
-        response.comments << "The record contains at least one of the required fields: #{@@required_fields.join(', ')}."
-        pass = true
-      else
-        @@required_fields.each do |field|
-          if field.include?(key) || key.include?(field)
-            response.score = 'pass'
-            response.comments << "The record contains at least one of the required fields: #{@@required_fields.join(', ')}."
-            pass = true
-          end
-        end
-      end
-    end
-    unless pass
+    if has_matching_key_with_value?(record, @@required_fields)
+      response.score = 'pass'
+      response.comments << "The record contains at least one of the required fields: #{@@required_fields.join(', ')}."
+    else
       response.score = 'fail'
       response.comments << "The record does not contain at least one of the required fields: #{@@required_fields.join(', ')}."
     end

--- a/test/fair_test_utils_test.rb
+++ b/test/fair_test_utils_test.rb
@@ -45,6 +45,24 @@ class FairTestUtilsTest < Minitest::Test
     assert_nil metadata_harvesting("https://example.org/records/abc123")
   end
 
+  def test_contains_meaningful_value_covers_all_value_types
+    refute contains_meaningful_value?(nil)
+
+    assert contains_meaningful_value?("title")
+    refute contains_meaningful_value?("  ")
+
+    assert contains_meaningful_value?(1)
+    refute contains_meaningful_value?(0)
+
+    assert contains_meaningful_value?(["title"])
+    refute contains_meaningful_value?([])
+
+    assert contains_meaningful_value?({ title: "A title" })
+    refute contains_meaningful_value?({})
+
+    assert contains_meaningful_value?(false)
+  end
+
   def test_resolves_dois
     fake_request = Object.new
     def fake_request.last_uri

--- a/test/fair_test_utils_test.rb
+++ b/test/fair_test_utils_test.rb
@@ -111,4 +111,6 @@ class FairTestUtilsTest < Minitest::Test
     assert_equal find_by_regex("FAIRsharing.123456"), {:message=>"Error getting record from FAIRsharing API: 404, "}
   end
 
+
+
 end

--- a/test/fair_test_utils_test.rb
+++ b/test/fair_test_utils_test.rb
@@ -26,6 +26,25 @@ class FairTestUtilsTest < Minitest::Test
     assert_equal res[:error].include?("Error parsing DOI metadata"), true
   end
 
+  def test_metadata_harvesting_returns_parsed_json
+    stub_request(:post, "https://tools.ostrails.eu/champion/harvest_only").
+      to_return(
+        status: 200,
+        body: { title: "This record passes" }.to_json,
+        headers: headers
+      )
+
+    assert_equal({ "title" => "This record passes" },
+                 metadata_harvesting("https://example.org/records/abc123"))
+  end
+
+  def test_metadata_harvesting_returns_nil_for_non_json
+    stub_request(:post, "https://tools.ostrails.eu/champion/harvest_only").
+      to_return(status: 200, body: "not json", headers: headers)
+
+    assert_nil metadata_harvesting("https://example.org/records/abc123")
+  end
+
   def test_resolves_dois
     fake_request = Object.new
     def fake_request.last_uri

--- a/test/ft_f2_m_discoveryfields_test.rb
+++ b/test/ft_f2_m_discoveryfields_test.rb
@@ -37,20 +37,9 @@ class FtF2MDiscoveryfieldsTest < Minitest::Test
       body: "https://example.org/records/abc123".to_json,
       headers: headers
     )
-    stub_request(:post, "https://tools.ostrails.eu/champion/harvest_only").
-      with(
-        body: "{\"resource_identifier\":\"https://example.org/records/abc123\"}",
-        headers: {
-          'Accept'=>'application/json',
-          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-          'Content-Type'=>'application/json',
-          'User-Agent'=>'Ruby'
-        }).
-      to_return(status: 200,
-                body: {
-                  title: "This record passes"
-                }.to_json,
-                headers: {})
+    stub_metadata_harvesting({
+      title: "This record passes"
+    })
 
     post '/test/ft_f2_m_discoveryfields',
          params: { resource_identifier: 'https://doi.org/10.25504/FAIRsharing.9kahy4'}.to_json,
@@ -63,20 +52,9 @@ class FtF2MDiscoveryfieldsTest < Minitest::Test
   end
 
   def test_non_doi_passes
-    stub_request(:post, "https://tools.ostrails.eu/champion/harvest_only").
-      with(
-        body: "{\"resource_identifier\":\"https://example.org/records/abc123\"}",
-        headers: {
-          'Accept'=>'application/json',
-          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-          'Content-Type'=>'application/json',
-          'User-Agent'=>'Ruby'
-        }).
-      to_return(status: 200,
-                body: {
-                  title: "This record passes"
-                }.to_json,
-                headers: {})
+    stub_metadata_harvesting({
+      title: "This record passes"
+    })
 
     post '/test/ft_f2_m_discoveryfields',
          params: { resource_identifier: 'https://example.org/records/abc123'}.to_json,
@@ -105,20 +83,9 @@ class FtF2MDiscoveryfieldsTest < Minitest::Test
         body: "https://example.org/records/abc123".to_json,
         headers: headers
       )
-    stub_request(:post, "https://tools.ostrails.eu/champion/harvest_only").
-      with(
-        body: "{\"resource_identifier\":\"https://example.org/records/abc123\"}",
-        headers: {
-          'Accept'=>'application/json',
-          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-          'Content-Type'=>'application/json',
-          'User-Agent'=>'Ruby'
-        }).
-      to_return(status: 200,
-                body: {
-                  title: "This record passes"
-                }.to_json,
-                headers: {})
+    stub_metadata_harvesting({
+      title: "This record passes"
+    })
 
 
     post '/test/ft_f2_m_discoveryfields',
@@ -152,18 +119,7 @@ class FtF2MDiscoveryfieldsTest < Minitest::Test
         body: "https://example.org/records/abc123".to_json,
         headers: headers
       )
-    stub_request(:post, "https://tools.ostrails.eu/champion/harvest_only").
-      with(
-        body: "{\"resource_identifier\":\"https://example.org/records/abc123\"}",
-        headers: {
-          'Accept'=>'application/json',
-          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-          'Content-Type'=>'application/json',
-          'User-Agent'=>'Ruby'
-        }).
-      to_return(status: 200,
-                body: {}.to_json,
-                headers: {})
+    stub_metadata_harvesting({})
 
     post '/test/ft_f2_m_discoveryfields',
          params: { resource_identifier: 'https://doi.org/10.1234/FAIRsharing.123456' }.to_json,
@@ -192,20 +148,9 @@ class FtF2MDiscoveryfieldsTest < Minitest::Test
       body: "https://example.org/records/abc123".to_json,
       headers: headers
     )
-    stub_request(:post, "https://tools.ostrails.eu/champion/harvest_only").
-      with(
-        body: "{\"resource_identifier\":\"https://example.org/records/abc123\"}",
-        headers: {
-          'Accept'=>'application/json',
-          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-          'Content-Type'=>'application/json',
-          'User-Agent'=>'Ruby'
-        }).
-      to_return(status: 200,
-                body: {
-                  codename: "This record fails"
-                }.to_json,
-                headers: {})
+    stub_metadata_harvesting({
+      codename: "This record fails"
+    })
 
     post '/test/ft_f2_m_discoveryfields',
          params: { resource_identifier: 'https://doi.org/10.1234/FAIRsharing.123456' }.to_json,
@@ -218,20 +163,9 @@ class FtF2MDiscoveryfieldsTest < Minitest::Test
   end
 
   def test_is_not_doi_and_fails
-    stub_request(:post, "https://tools.ostrails.eu/champion/harvest_only").
-      with(
-        body: "{\"resource_identifier\":\"https://example.org/records/abc123\"}",
-        headers: {
-          'Accept'=>'application/json',
-          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-          'Content-Type'=>'application/json',
-          'User-Agent'=>'Ruby'
-        }).
-      to_return(status: 200,
-                body: {
-                  codename: "This record fails"
-                }.to_json,
-                headers: {})
+    stub_metadata_harvesting({
+      codename: "This record fails"
+    })
 
     post '/test/ft_f2_m_discoveryfields',
          params: { resource_identifier: 'https://example.org/records/abc123' }.to_json,
@@ -261,16 +195,7 @@ class FtF2MDiscoveryfieldsTest < Minitest::Test
         body: "https://example.org/records/abc123".to_json,
         headers: headers
       )
-    stub_request(:post, "https://tools.ostrails.eu/champion/harvest_only").
-      with(
-        body: "{\"resource_identifier\":\"https://example.org/records/abc123\"}",
-        headers: {
-          'Accept'=>'application/json',
-          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-          'Content-Type'=>'application/json',
-          'User-Agent'=>'Ruby'
-        }).
-      to_return(status: 200, body: "", headers: {})
+    stub_metadata_harvesting("")
 
 
     post '/test/ft_f2_m_discoveryfields',
@@ -284,18 +209,7 @@ class FtF2MDiscoveryfieldsTest < Minitest::Test
   end
 
   def test_is_not_doi_and_indeterminate
-    stub_request(:post, "https://tools.ostrails.eu/champion/harvest_only").
-      with(
-        body: "{\"resource_identifier\":\"https://example.org/records/abc123\"}",
-        headers: {
-          'Accept'=>'application/json',
-          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-          'Content-Type'=>'application/json',
-          'User-Agent'=>'Ruby'
-        }).
-      to_return(status: 200,
-                body: {}.to_json,
-                headers: {})
+    stub_metadata_harvesting({})
 
     post '/test/ft_f2_m_discoveryfields',
          params: { resource_identifier: 'https://example.org/records/abc123' }.to_json,
@@ -312,18 +226,7 @@ class FtF2MDiscoveryfieldsTest < Minitest::Test
   #######################
   def test_ora_data_passes
     json_file = JSON.load_file('test/fixtures/example_pass_fixture.json')
-    stub_request(:post, "https://tools.ostrails.eu/champion/harvest_only").
-      with(
-        body: "{\"resource_identifier\":\"https://example.org/records/abc123\"}",
-        headers: {
-          'Accept'=>'application/json',
-          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-          'Content-Type'=>'application/json',
-          'User-Agent'=>'Ruby'
-        }).
-      to_return(status: 200,
-                body: json_file.to_json,
-                headers: {})
+    stub_metadata_harvesting(json_file)
 
 
     post '/test/ft_f2_m_discoveryfields',
@@ -338,18 +241,7 @@ class FtF2MDiscoveryfieldsTest < Minitest::Test
 
   def test_ora_data_fails
     json_file = JSON.load_file('test/fixtures/example_fail_discoveryfields_fixture.json')
-    stub_request(:post, "https://tools.ostrails.eu/champion/harvest_only").
-      with(
-        body: "{\"resource_identifier\":\"https://example.org/records/abc123\"}",
-        headers: {
-          'Accept'=>'application/json',
-          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-          'Content-Type'=>'application/json',
-          'User-Agent'=>'Ruby'
-        }).
-      to_return(status: 200,
-                body: json_file.to_json,
-                headers: {})
+    stub_metadata_harvesting(json_file)
 
     post '/test/ft_f2_m_discoveryfields',
          params: { resource_identifier: 'https://example.org/records/abc123' }.to_json,

--- a/test/ft_f2_m_discoveryfields_test.rb
+++ b/test/ft_f2_m_discoveryfields_test.rb
@@ -37,14 +37,20 @@ class FtF2MDiscoveryfieldsTest < Minitest::Test
       body: "https://example.org/records/abc123".to_json,
       headers: headers
     )
-    stub_request(:get, "https://example.org/records/abc123").
-      to_return(
-      status: 200,
-      body: {
-        title: "This record passes"
-      }.to_json,
-      headers: headers
-    )
+    stub_request(:post, "https://tools.ostrails.eu/champion/harvest_only").
+      with(
+        body: "{\"resource_identifier\":\"https://example.org/records/abc123\"}",
+        headers: {
+          'Accept'=>'application/json',
+          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+          'Content-Type'=>'application/json',
+          'User-Agent'=>'Ruby'
+        }).
+      to_return(status: 200,
+                body: {
+                  title: "This record passes"
+                }.to_json,
+                headers: {})
 
     post '/test/ft_f2_m_discoveryfields',
          params: { resource_identifier: 'https://doi.org/10.25504/FAIRsharing.9kahy4'}.to_json,
@@ -57,14 +63,20 @@ class FtF2MDiscoveryfieldsTest < Minitest::Test
   end
 
   def test_non_doi_passes
-    stub_request(:get, "https://example.org/records/abc123").
-      to_return(
-        status: 200,
-        body: {
-          title: "This record passes"
-        }.to_json,
-        headers: headers
-      )
+    stub_request(:post, "https://tools.ostrails.eu/champion/harvest_only").
+      with(
+        body: "{\"resource_identifier\":\"https://example.org/records/abc123\"}",
+        headers: {
+          'Accept'=>'application/json',
+          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+          'Content-Type'=>'application/json',
+          'User-Agent'=>'Ruby'
+        }).
+      to_return(status: 200,
+                body: {
+                  title: "This record passes"
+                }.to_json,
+                headers: {})
 
     post '/test/ft_f2_m_discoveryfields',
          params: { resource_identifier: 'https://example.org/records/abc123'}.to_json,
@@ -93,14 +105,21 @@ class FtF2MDiscoveryfieldsTest < Minitest::Test
         body: "https://example.org/records/abc123".to_json,
         headers: headers
       )
-    stub_request(:get, "https://example.org/records/abc123").
-      to_return(
-        status: 200,
-        body: {
-          title: "This record passes"
-        }.to_json,
-        headers: headers
-      )
+    stub_request(:post, "https://tools.ostrails.eu/champion/harvest_only").
+      with(
+        body: "{\"resource_identifier\":\"https://example.org/records/abc123\"}",
+        headers: {
+          'Accept'=>'application/json',
+          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+          'Content-Type'=>'application/json',
+          'User-Agent'=>'Ruby'
+        }).
+      to_return(status: 200,
+                body: {
+                  title: "This record passes"
+                }.to_json,
+                headers: {})
+
 
     post '/test/ft_f2_m_discoveryfields',
          params: { resource_identifier: 'https://doi.org/10.1234/FAIRsharing.123456' }.to_json,
@@ -133,12 +152,18 @@ class FtF2MDiscoveryfieldsTest < Minitest::Test
         body: "https://example.org/records/abc123".to_json,
         headers: headers
       )
-    stub_request(:get, "https://example.org/records/abc123").
-      to_return(
-        status: 200,
-        body: {}.to_json,
-        headers: headers
-      )
+    stub_request(:post, "https://tools.ostrails.eu/champion/harvest_only").
+      with(
+        body: "{\"resource_identifier\":\"https://example.org/records/abc123\"}",
+        headers: {
+          'Accept'=>'application/json',
+          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+          'Content-Type'=>'application/json',
+          'User-Agent'=>'Ruby'
+        }).
+      to_return(status: 200,
+                body: {}.to_json,
+                headers: {})
 
     post '/test/ft_f2_m_discoveryfields',
          params: { resource_identifier: 'https://doi.org/10.1234/FAIRsharing.123456' }.to_json,
@@ -167,14 +192,20 @@ class FtF2MDiscoveryfieldsTest < Minitest::Test
       body: "https://example.org/records/abc123".to_json,
       headers: headers
     )
-    stub_request(:get, "https://example.org/records/abc123").
-      to_return(
-        status: 200,
-        body: {
-          codename: "This record fails"
-        }.to_json,
-        headers: headers
-      )
+    stub_request(:post, "https://tools.ostrails.eu/champion/harvest_only").
+      with(
+        body: "{\"resource_identifier\":\"https://example.org/records/abc123\"}",
+        headers: {
+          'Accept'=>'application/json',
+          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+          'Content-Type'=>'application/json',
+          'User-Agent'=>'Ruby'
+        }).
+      to_return(status: 200,
+                body: {
+                  codename: "This record fails"
+                }.to_json,
+                headers: {})
 
     post '/test/ft_f2_m_discoveryfields',
          params: { resource_identifier: 'https://doi.org/10.1234/FAIRsharing.123456' }.to_json,
@@ -187,15 +218,20 @@ class FtF2MDiscoveryfieldsTest < Minitest::Test
   end
 
   def test_is_not_doi_and_fails
-
-    stub_request(:get, "https://example.org/records/abc123").
-      to_return(
-        status: 200,
-        body: {
-          codename: "This record fails"
-        }.to_json,
-        headers: headers
-      )
+    stub_request(:post, "https://tools.ostrails.eu/champion/harvest_only").
+      with(
+        body: "{\"resource_identifier\":\"https://example.org/records/abc123\"}",
+        headers: {
+          'Accept'=>'application/json',
+          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+          'Content-Type'=>'application/json',
+          'User-Agent'=>'Ruby'
+        }).
+      to_return(status: 200,
+                body: {
+                  codename: "This record fails"
+                }.to_json,
+                headers: {})
 
     post '/test/ft_f2_m_discoveryfields',
          params: { resource_identifier: 'https://example.org/records/abc123' }.to_json,
@@ -225,12 +261,17 @@ class FtF2MDiscoveryfieldsTest < Minitest::Test
         body: "https://example.org/records/abc123".to_json,
         headers: headers
       )
-    stub_request(:get, "https://example.org/records/abc123").
-      to_return(
-        status: 200,
-        body: {}.to_json,
-        headers: headers
-      )
+    stub_request(:post, "https://tools.ostrails.eu/champion/harvest_only").
+      with(
+        body: "{\"resource_identifier\":\"https://example.org/records/abc123\"}",
+        headers: {
+          'Accept'=>'application/json',
+          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+          'Content-Type'=>'application/json',
+          'User-Agent'=>'Ruby'
+        }).
+      to_return(status: 200, body: "", headers: {})
+
 
     post '/test/ft_f2_m_discoveryfields',
          params: { resource_identifier: 'https://doi.org/10.1234/FAIRsharing.123456' }.to_json,
@@ -243,13 +284,18 @@ class FtF2MDiscoveryfieldsTest < Minitest::Test
   end
 
   def test_is_not_doi_and_indeterminate
-
-    stub_request(:get, "https://example.org/records/abc123").
-      to_return(
-        status: 200,
-        body: {}.to_json,
-        headers: headers
-      )
+    stub_request(:post, "https://tools.ostrails.eu/champion/harvest_only").
+      with(
+        body: "{\"resource_identifier\":\"https://example.org/records/abc123\"}",
+        headers: {
+          'Accept'=>'application/json',
+          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+          'Content-Type'=>'application/json',
+          'User-Agent'=>'Ruby'
+        }).
+      to_return(status: 200,
+                body: {}.to_json,
+                headers: {})
 
     post '/test/ft_f2_m_discoveryfields',
          params: { resource_identifier: 'https://example.org/records/abc123' }.to_json,
@@ -266,12 +312,19 @@ class FtF2MDiscoveryfieldsTest < Minitest::Test
   #######################
   def test_ora_data_passes
     json_file = JSON.load_file('test/fixtures/example_pass_fixture.json')
-    stub_request(:get, "https://example.org/records/abc123").
-      to_return(
-        status: 200,
-        body: json_file.to_json,
-        headers: headers
-      )
+    stub_request(:post, "https://tools.ostrails.eu/champion/harvest_only").
+      with(
+        body: "{\"resource_identifier\":\"https://example.org/records/abc123\"}",
+        headers: {
+          'Accept'=>'application/json',
+          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+          'Content-Type'=>'application/json',
+          'User-Agent'=>'Ruby'
+        }).
+      to_return(status: 200,
+                body: json_file.to_json,
+                headers: {})
+
 
     post '/test/ft_f2_m_discoveryfields',
          params: { resource_identifier: 'https://example.org/records/abc123' }.to_json,
@@ -285,12 +338,18 @@ class FtF2MDiscoveryfieldsTest < Minitest::Test
 
   def test_ora_data_fails
     json_file = JSON.load_file('test/fixtures/example_fail_discoveryfields_fixture.json')
-    stub_request(:get, "https://example.org/records/abc123").
-      to_return(
-        status: 200,
-        body: json_file.to_json,
-        headers: headers
-      )
+    stub_request(:post, "https://tools.ostrails.eu/champion/harvest_only").
+      with(
+        body: "{\"resource_identifier\":\"https://example.org/records/abc123\"}",
+        headers: {
+          'Accept'=>'application/json',
+          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+          'Content-Type'=>'application/json',
+          'User-Agent'=>'Ruby'
+        }).
+      to_return(status: 200,
+                body: json_file.to_json,
+                headers: {})
 
     post '/test/ft_f2_m_discoveryfields',
          params: { resource_identifier: 'https://example.org/records/abc123' }.to_json,

--- a/test/ft_f2_m_discoverypublisher_test.rb
+++ b/test/ft_f2_m_discoverypublisher_test.rb
@@ -37,14 +37,9 @@ class FtF2MDiscoverypublisherTest < Minitest::Test
         body: "https://example.org/records/abc123".to_json,
         headers: headers
       )
-    stub_request(:get, "https://example.org/records/abc123").
-      to_return(
-        status: 200,
-        body: {
-          publisher: "This record passes publishing co."
-        }.to_json,
-        headers: headers
-      )
+    stub_metadata_harvesting({
+      publisher: "This record passes publishing co."
+    })
 
     post '/test/ft_f2_m_discoverypublisher',
          params: { resource_identifier: 'https://doi.org/10.25504/FAIRsharing.9kahy4'}.to_json,
@@ -57,14 +52,9 @@ class FtF2MDiscoverypublisherTest < Minitest::Test
   end
 
   def test_non_doi_passes
-    stub_request(:get, "https://example.org/records/abc123").
-      to_return(
-        status: 200,
-        body: {
-          publisher: "This record passes publishing co."
-        }.to_json,
-        headers: headers
-      )
+    stub_metadata_harvesting({
+      publisher: "This record passes publishing co."
+    })
 
     post '/test/ft_f2_m_discoverypublisher',
          params: { resource_identifier: 'https://example.org/records/abc123'}.to_json,
@@ -93,14 +83,9 @@ class FtF2MDiscoverypublisherTest < Minitest::Test
         body: "https://example.org/records/abc123".to_json,
         headers: headers
       )
-    stub_request(:get, "https://example.org/records/abc123").
-      to_return(
-        status: 200,
-        body: {
-          publisher: "This record passes publishing co."
-        }.to_json,
-        headers: headers
-      )
+    stub_metadata_harvesting({
+      publisher: "This record passes publishing co."
+    })
 
     post '/test/ft_f2_m_discoverypublisher',
          params: { resource_identifier: 'https://doi.org/10.1234/FAIRsharing.123456' }.to_json,
@@ -134,12 +119,7 @@ class FtF2MDiscoverypublisherTest < Minitest::Test
         body: "https://example.org/records/abc123".to_json,
         headers: headers
       )
-    stub_request(:get, "https://example.org/records/abc123").
-      to_return(
-        status: 200,
-        body: {}.to_json,
-        headers: headers
-      )
+    stub_metadata_harvesting({})
 
     post '/test/ft_f2_m_discoverypublisher',
          params: { resource_identifier: 'https://doi.org/10.1234/FAIRsharing.123456' }.to_json,
@@ -168,14 +148,9 @@ class FtF2MDiscoverypublisherTest < Minitest::Test
         body: "https://example.org/records/abc123".to_json,
         headers: headers
       )
-    stub_request(:get, "https://example.org/records/abc123").
-      to_return(
-        status: 200,
-        body: {
-          codename: "This record fails"
-        }.to_json,
-        headers: headers
-      )
+    stub_metadata_harvesting({
+      codename: "This record fails"
+    })
 
     post '/test/ft_f2_m_discoverypublisher',
          params: { resource_identifier: 'https://doi.org/10.1234/FAIRsharing.123456' }.to_json,
@@ -189,14 +164,9 @@ class FtF2MDiscoverypublisherTest < Minitest::Test
 
   def test_is_not_doi_and_fails
 
-    stub_request(:get, "https://example.org/records/abc123").
-      to_return(
-        status: 200,
-        body: {
-          codename: "This record fails"
-        }.to_json,
-        headers: headers
-      )
+    stub_metadata_harvesting({
+      codename: "This record fails"
+    })
 
     post '/test/ft_f2_m_discoverypublisher',
          params: { resource_identifier: 'https://example.org/records/abc123' }.to_json,
@@ -226,12 +196,7 @@ class FtF2MDiscoverypublisherTest < Minitest::Test
         body: "https://example.org/records/abc123".to_json,
         headers: headers
       )
-    stub_request(:get, "https://example.org/records/abc123").
-      to_return(
-        status: 200,
-        body: {}.to_json,
-        headers: headers
-      )
+    stub_metadata_harvesting({})
 
     post '/test/ft_f2_m_discoverypublisher',
          params: { resource_identifier: 'https://doi.org/10.1234/FAIRsharing.123456' }.to_json,
@@ -245,12 +210,7 @@ class FtF2MDiscoverypublisherTest < Minitest::Test
 
   def test_is_not_doi_and_indeterminate
 
-    stub_request(:get, "https://example.org/records/abc123").
-      to_return(
-        status: 200,
-        body: {}.to_json,
-        headers: headers
-      )
+    stub_metadata_harvesting({})
 
     post '/test/ft_f2_m_discoverypublisher',
          params: { resource_identifier: 'https://example.org/records/abc123' }.to_json,
@@ -267,12 +227,7 @@ class FtF2MDiscoverypublisherTest < Minitest::Test
   #######################
   def test_ora_data_passes
     json_file = JSON.load_file('test/fixtures/example_pass_fixture.json')
-    stub_request(:get, "https://example.org/records/abc123").
-      to_return(
-        status: 200,
-        body: json_file.to_json,
-        headers: headers
-      )
+    stub_metadata_harvesting(json_file)
 
     post '/test/ft_f2_m_discoverypublisher',
          params: { resource_identifier: 'https://example.org/records/abc123' }.to_json,
@@ -286,12 +241,7 @@ class FtF2MDiscoverypublisherTest < Minitest::Test
 
   def test_ora_data_fails
     json_file = JSON.load_file('test/fixtures/example_fail_discoverypublisher_fixture.json')
-    stub_request(:get, "https://example.org/records/abc123").
-      to_return(
-        status: 200,
-        body: json_file.to_json,
-        headers: headers
-      )
+    stub_metadata_harvesting(json_file)
 
     post '/test/ft_f2_m_discoverypublisher',
          params: { resource_identifier: 'https://example.org/records/abc123' }.to_json,

--- a/test/ft_f2_m_discoverytags_test.rb
+++ b/test/ft_f2_m_discoverytags_test.rb
@@ -37,14 +37,9 @@ class FtF2MDiscoverytagsTest < Minitest::Test
         body: "https://example.org/records/abc123".to_json,
         headers: headers
       )
-    stub_request(:get, "https://example.org/records/abc123").
-      to_return(
-        status: 200,
-        body: {
-          keywords: %w[This record passes]
-        }.to_json,
-        headers: headers
-      )
+    stub_metadata_harvesting({
+      keywords: %w[This record passes]
+    })
 
     post '/test/ft_f2_m_discoverytags',
          params: { resource_identifier: 'https://doi.org/10.25504/FAIRsharing.9kahy4'}.to_json,
@@ -73,14 +68,9 @@ class FtF2MDiscoverytagsTest < Minitest::Test
         body: "https://example.org/records/abc123".to_json,
         headers: headers
       )
-    stub_request(:get, "https://example.org/records/abc123").
-      to_return(
-        status: 200,
-        body: {
-          keywords: %w[This record passes]
-        }.to_json,
-        headers: headers
-      )
+    stub_metadata_harvesting({
+      keywords: %w[This record passes]
+    })
 
     post '/test/ft_f2_m_discoverytags',
          params: { resource_identifier: 'https://doi.org/10.1234/FAIRsharing.123456' }.to_json,
@@ -109,12 +99,7 @@ class FtF2MDiscoverytagsTest < Minitest::Test
         body: "https://example.org/records/abc123".to_json,
         headers: headers
       )
-    stub_request(:get, "https://example.org/records/abc123").
-      to_return(
-        status: 200,
-        body: {}.to_json,
-        headers: headers
-      )
+    stub_metadata_harvesting({})
 
     post '/test/ft_f2_m_discoverytags',
          params: { resource_identifier: 'https://doi.org/10.1234/FAIRsharing.123456' }.to_json,
@@ -127,14 +112,9 @@ class FtF2MDiscoverytagsTest < Minitest::Test
   end
 
   def test_non_doi_passes
-    stub_request(:get, "https://example.org/records/abc123").
-      to_return(
-        status: 200,
-        body: {
-          keywords: %w[This record passes]
-        }.to_json,
-        headers: headers
-      )
+    stub_metadata_harvesting({
+      keywords: %w[This record passes]
+    })
 
     post '/test/ft_f2_m_discoverytags',
          params: { resource_identifier: 'https://example.org/records/abc123'}.to_json,
@@ -166,14 +146,9 @@ class FtF2MDiscoverytagsTest < Minitest::Test
         body: "https://example.org/records/abc123".to_json,
         headers: headers
       )
-    stub_request(:get, "https://example.org/records/abc123").
-      to_return(
-        status: 200,
-        body: {
-          codename: "This record fails"
-        }.to_json,
-        headers: headers
-      )
+    stub_metadata_harvesting({
+      codename: "This record fails"
+    })
 
     post '/test/ft_f2_m_discoverytags',
          params: { resource_identifier: 'https://doi.org/10.1234/FAIRsharing.123456' }.to_json,
@@ -187,14 +162,9 @@ class FtF2MDiscoverytagsTest < Minitest::Test
 
   def test_is_not_doi_and_fails
 
-    stub_request(:get, "https://example.org/records/abc123").
-      to_return(
-        status: 200,
-        body: {
-          codename: "This record fails"
-        }.to_json,
-        headers: headers
-      )
+    stub_metadata_harvesting({
+      codename: "This record fails"
+    })
 
     post '/test/ft_f2_m_discoverytags',
          params: { resource_identifier: 'https://example.org/records/abc123' }.to_json,
@@ -224,12 +194,7 @@ class FtF2MDiscoverytagsTest < Minitest::Test
         body: "https://example.org/records/abc123".to_json,
         headers: headers
       )
-    stub_request(:get, "https://example.org/records/abc123").
-      to_return(
-        status: 200,
-        body: {}.to_json,
-        headers: headers
-      )
+    stub_metadata_harvesting({})
 
     post '/test/ft_f2_m_discoverytags',
          params: { resource_identifier: 'https://doi.org/10.1234/FAIRsharing.123456' }.to_json,
@@ -243,12 +208,7 @@ class FtF2MDiscoverytagsTest < Minitest::Test
 
   def test_is_not_doi_and_indeterminate
 
-    stub_request(:get, "https://example.org/records/abc123").
-      to_return(
-        status: 200,
-        body: {}.to_json,
-        headers: headers
-      )
+    stub_metadata_harvesting({})
 
     post '/test/ft_f2_m_discoverytags',
          params: { resource_identifier: 'https://example.org/records/abc123' }.to_json,
@@ -265,12 +225,7 @@ class FtF2MDiscoverytagsTest < Minitest::Test
   #######################
   def test_ora_data_passes
     json_file = JSON.load_file('test/fixtures/example_pass_fixture.json')
-    stub_request(:get, "https://example.org/records/abc123").
-      to_return(
-        status: 200,
-        body: json_file.to_json,
-        headers: headers
-      )
+    stub_metadata_harvesting(json_file)
 
     post '/test/ft_f2_m_discoverytags',
          params: { resource_identifier: 'https://example.org/records/abc123' }.to_json,
@@ -284,12 +239,7 @@ class FtF2MDiscoverytagsTest < Minitest::Test
 
   def test_ora_data_fails
     json_file = JSON.load_file('test/fixtures/example_fail_discoverytags_fixture.json')
-    stub_request(:get, "https://example.org/records/abc123").
-      to_return(
-        status: 200,
-        body: json_file.to_json,
-        headers: headers
-      )
+    stub_metadata_harvesting(json_file)
 
     post '/test/ft_f2_m_discoverytags',
          params: { resource_identifier: 'https://example.org/records/abc123' }.to_json,

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -20,6 +20,25 @@ module TestHelper
     FairTests
   end
 
+  CHAMPION_URL = "https://tools.ostrails.eu/champion/harvest_only"
+  CHAMPION_HEADERS = {
+    'Accept'=>'application/json',
+    'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+    'Content-Type'=>'application/json',
+    'User-Agent'=>'Ruby'
+  }
+
+  def stub_metadata_harvesting(response_body, resource_identifier: "https://example.org/records/abc123")
+    body = response_body.is_a?(String) ? response_body : response_body.to_json
+
+    stub_request(:post, CHAMPION_URL).
+      with(
+        body: { resource_identifier: resource_identifier }.to_json,
+        headers: CHAMPION_HEADERS
+      ).
+      to_return(status: 200, body: body, headers: {})
+  end
+
   def headers
     {
       'Content-Type' => 'application/json',


### PR DESCRIPTION
This PR changes the three tests which were using a crude means of content negotiation to use the metadata harvester.
Although this is still buggy (see https://github.com/markwilkinson/FAIR-Champion/issues/18) it works on ORA and Figshare records and so is worth using. Any data about FAIRsharing records can be obtained via the GraphQL API until (and even after) this is fixed. 
@allysonlister I've not assigned you for review as this is only a technical change; there are no issues relating to test descriptions, relevant metrics etc. 