### PR TITLE
RG_ORA_Test_R1_2_ROR_ID#59

### DIFF
--- a/lib/fair_tests/ft_r1_2_ror_id_for_funder.rb
+++ b/lib/fair_tests/ft_r1_2_ror_id_for_funder.rb
@@ -1,0 +1,58 @@
+module FtR12RorIdForFunder
+  require 'ftr_ruby'
+  require_relative '../fair_test_utils'
+  include FairTestUtils
+
+  def ft_r1_2_ror_id_for_funder(url_record)
+    record = metadata_harvesting(url_record)
+
+    meta = {
+      testid: 'ft_r1_2_ror_id_for_funder',
+      testname: 'FAIR Test – R1.2 - ROR ID for funder',
+      description: 'This test evaluates whether the metadata includes at least one ROR ID for a funder associated with the research object. The assessment checks for structured funding references within both the landing page metadata and the central records held by DOI registration agencies (such as DataCite or Crossref). Specifically, it verifies that fields such as fundingReferences (DataCite) or funder (Crossref) are populated with at least one funder ROR ID. It checks the record’s landing page for embedded or linked structured data that can be successfully parsed against the declared community schema. If the record contains ROR identifiers it will pass; otherwise, the test will fail.',
+      keywords: ['FAIR', 'R1.2', 'ror id'],
+      creator: 'https://orcid.org/0000-0002-6468-9260',
+      indicators: [],
+      metric: 'https://fairsharing.org/8185',
+      license: 'https://creativecommons.org/licenses/by/4.0/',
+      testversion: '1.0.0',
+      protocol: 'https',
+      host: 'fair-tests.fairsharing.org',
+      basePath: 'test'
+    }
+
+    response = FtrRuby::Output.new(
+      testedGUID: url_record,
+      meta: meta,
+      )
+
+    if record && !record.empty?
+      pass = false
+      identifiers = find_schema_property_value_triples(record)
+      if identifiers.empty?
+        response.score = 'fail'
+        response.comments << 'This record does not contain ROR identifiers.'
+      else
+        identifiers.each do |identifier|
+          property_ids = schema_object_values(identifier, 'propertyID')
+
+          if (property_ids & %w[ROR]).any?
+            pass = true
+            break
+          end
+        end
+
+        if pass
+          response.score = 'pass'
+          response.comments << 'This record contains ROR identifiers.'
+        else
+          response.score = 'fail'
+          response.comments << 'This record does not contain ROR identifiers.'
+        end
+      end
+    end
+
+    response.createEvaluationResponse
+
+  end
+end

--- a/public/test_descriptions/ft_r1_2_ror_id_for_funder/api
+++ b/public/test_descriptions/ft_r1_2_ror_id_for_funder/api
@@ -1,0 +1,38 @@
+openapi: 3.0.0
+info:
+  version: "1.0"
+  title: "FAIR Test – R1.2 - ROR ID for funder"
+  x-tests_metric: "https://fairsharing.org/8185"
+  description: >-
+      "This test evaluates whether the metadata includes at least one ROR ID for a funder associated with the research object. The assessment checks for structured funding references within both the landing page metadata and the central records held by DOI registration agencies (such as DataCite or Crossref). Specifically, it verifies that fields such as fundingReferences (DataCite) or funder (Crossref) are populated with at least one funder ROR ID. It checks the record’s landing page for embedded or linked structured data that can be successfully parsed against the declared community schema. If the record contains ROR identifiers it will pass; otherwise, the test will fail"
+  x-applies_to_principle: "https://doi.org/10.25504/FAIRsharing.3e9860"
+  contact:
+    x-organization: "FAIRsharing, Oxford University"
+    url: "https://fairsharing.org"
+    name: "FAIRsharing Support"
+    email: "contact@fairsharing.org"
+paths:
+  "/ft_r1_2_ror_id_for_funder":
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/schemas"
+        required: true
+      responses:
+        "200":
+          description:  >-
+            The response is "pass", "fail" or "indeterminate"
+servers:
+  - url: "https://fair-tests.fairsharing.org/test"
+components:
+  schemas:
+    schemas:
+      required:
+        - resource_identifier
+      properties:
+      - resource_identifier:
+          type: string
+          description: the GUID being tested
+

--- a/test/ft_r1_2_ror_id_for_funder_test.rb
+++ b/test/ft_r1_2_ror_id_for_funder_test.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+require_relative './test_helper'
+require 'webmock/minitest'
+require_relative '../lib/fair_tests/ft_r1_2_ror_id_for_funder'
+
+class FtR12RorIdForFunderTest < Minitest::Test
+  include ::TestHelper
+  include ::FtF1MMetadataIdPersistent
+
+  def test_passes_when_schema_property_value_triple_contains_ror
+    stub_metadata_harvesting(
+      {
+        '@graph' => [
+          {
+            '@id' => 'urn:local:harvester:graph',
+            'local:triples' => [
+              {
+                '@id' => 'uuid:example',
+                '@type' => ['http://schema.org/Dataset']
+              },
+              {
+                '@id' => '_:identifier',
+                '@type' => ['http://schema.org/PropertyValue'],
+                'http://schema.org/propertyID' => [{ '@value' => 'ROR' }],
+                'http://schema.org/url' => [{ '@id' => 'https://ror.org/0439y7842' }]
+              }
+            ]
+          }
+        ]
+      }
+    )
+
+    post '/test/ft_r1_2_ror_id_for_funder',
+         params: { resource_identifier: 'https://example.org/records/abc123' }.to_json,
+         headers: headers
+
+    assert last_response.ok?
+
+    body = parsed_response_body(last_response.body)
+    assert_equal 'pass', find_prov_value(body)
+  end
+
+
+
+  def test_fails_when_no_schema_property_value_triples_exist
+    stub_metadata_harvesting(
+      {
+        '@graph' => [
+          {
+            '@id' => 'urn:local:harvester:graph',
+            'local:triples' => [
+              {
+                '@id' => 'uuid:example',
+                '@type' => ['http://schema.org/Dataset']
+              }
+            ]
+          }
+        ]
+      }
+    )
+
+    post '/test/ft_r1_2_ror_id_for_funder',
+         params: { resource_identifier: 'https://example.org/records/abc123' }.to_json,
+         headers: headers
+
+    assert last_response.ok?
+
+    body = parsed_response_body(last_response.body)
+    assert_equal 'fail', find_prov_value(body)
+  end
+
+  def test_fails_when_schema_property_value_not_labelled_as_and_not_ror
+    stub_metadata_harvesting(
+      {
+        '@graph' => [
+          {
+            '@id' => 'urn:local:harvester:graph',
+            'local:triples' => [
+              {
+                '@id' => 'uuid:example',
+                '@type' => ['http://schema.org/Dataset']
+              },
+              {
+                '@id' => '_:identifier',
+                '@type' => ['http://schema.org/PropertyValue'],
+                'http://schema.org/propertyID' => [{ '@value' => 'UNKNOWN' }],
+                'http://schema.org/url' => [{ '@id' => 'https://example.com/not_a_ror' }]
+              }
+            ]
+          }
+        ]
+      }
+    )
+
+    post '/test/ft_r1_2_ror_id_for_funder',
+         params: { resource_identifier: 'https://example.org/records/abc123' }.to_json,
+         headers: headers
+
+    assert last_response.ok?
+
+    body = parsed_response_body(last_response.body)
+    assert_equal 'fail', find_prov_value(body)
+  end
+end


### PR DESCRIPTION
This is for test #59 and it only looks for that the harvested object obtained by the given URL contains ROR:
       "@type"=>["http://schema.org/PropertyValue"],
       "http://schema.org/propertyID"=>[{"@value"=>"ROR"}],


To run it:
bundle exec irb
require_relative './lib/fair_tests/ft_r1_2_ror_id_for_funder.rb'; include FtR12RorIdForFunder
data = ft_r1_2_ror_id_for_funder('https://www.ora.ox.ac.uk/objects/uuid:54b52d1b-04cf-4243-aa79-d6ef3e53b6d4')


Do I need to add the test in the Wizard @allysonlister ?