### PR TITLE
Rg test r1 2 creator orcids#11

### DIFF
--- a/lib/fair_test_utils.rb
+++ b/lib/fair_test_utils.rb
@@ -195,6 +195,51 @@ module FairTestUtils
     results
   end
 
+  # This will look through the output of the metadata harvester and find all objects
+  # that were in a hash element that the key matches val_keys based on property
+  # For example, find_schema_object_values({"a1" :{"a2": [v1, v2]}, "a2": "text"}, "a2")
+  # will return [[v1, v2], "text"]
+  def find_schema_object_values(obj, property_name, results = [])
+    val_keys = [
+      property_name,
+      "schema:#{property_name}",
+      "http://schema.org/#{property_name}"
+    ]
+    case obj
+    when Hash
+      obj.each do |key, value|
+        results << value if val_keys.to_s.downcase.include?(key.downcase)
+        find_schema_object_values(value, property_name, results)
+      end
+    when Array
+      obj.each do |item|
+        find_schema_object_values(item, property_name, results)
+      end
+    end
+
+    results
+  end
+
+  # This will look through the output of the metadata harvester and find all hash tables H
+  # that have a key equal to "key_name" and H[key] is equal to value_to_match
+  def find_all_schema_object_key_value(obj, key_name, value_to_match, results = [])
+
+    case obj
+    when Hash
+      obj.each do |key, value|
+        results << obj if key_name.to_s == key.downcase && value.is_a?(String) && value == value_to_match
+
+        find_all_schema_object_key_value(value, key_name, value_to_match, results)
+      end
+    when Array
+      obj.each do |item|
+        find_all_schema_object_key_value(item, key_name, value_to_match, results)
+      end
+    end
+
+    results
+  end
+
   def schema_object_values(obj, property_name)
     return [] unless obj.is_a?(Hash)
 

--- a/lib/fair_tests/ft_r1_2_m_creator_orcid.rb
+++ b/lib/fair_tests/ft_r1_2_m_creator_orcid.rb
@@ -1,4 +1,4 @@
-module FtR12MRorIdForFunder
+module FtR12MCreatorOrcid
   require 'ftr_ruby'
   require_relative '../fair_test_utils'
   include FairTestUtils
@@ -29,37 +29,40 @@ module FtR12MRorIdForFunder
     if record && !record.empty?
       pass = false
       identifiers = find_schema_property_value_triples(record)
-      creators = find_schema_object_values(record,'creator')
-      if identifiers.empty? || creators.empty?
-        response.score = 'fail'
-        response.comments << 'This record does not contain a creator with ORCID ID.'
-      else
-        con_ids = []
-        find_schema_object_values(creators,'@id').each do |id_c|
+      creators = find_schema_object_values(record, 'creator')
+      # con_ids will contain the ID of an element that is connected to the creators.
+      # These elements need to be checked if it is ORCID
+      con_ids = []
+      unless creators.empty?
+        find_schema_object_values(creators[0], '@id').each do |id_c|
           next unless id_c.is_a?(String)
+
           find_all_schema_object_key_value(record, '@id', id_c).each do |c|
             schema_object_values(c, 'identifier').each do |d|
-              con_ids << d[0]
+              next unless d.is_a?(String)
+
+              con_ids << d unless d.empty?
             end
           end
         end
-
-
+      end
+      if identifiers.empty? || creators.empty? || con_ids.empty?
+        response.score = 'fail'
+        response.comments << 'This record does not contain a creator with ORCID ID.'
+      else
         identifiers.each do |identifier|
           property_ids = schema_object_values(identifier, 'propertyID')
-
-          if (property_ids & %w[ORCID]).any? && identifier.include?('@ID') && con_ids.include?(identifier['@ID'])
+          if (property_ids & %w[ORCID]).any? && identifier.include?('@id') && con_ids.include?(identifier['@id'])
             pass = true
             break
           end
         end
-
         if pass
           response.score = 'pass'
-          response.comments << 'This record contains ROR identifiers.'
+          response.comments << 'This record contains a creator with ORCID ID.'
         else
           response.score = 'fail'
-          response.comments << 'This record does not contain ROR identifiers.'
+          response.comments << 'This record does not contain a creator with ORCID ID.'
         end
       end
     end

--- a/lib/fair_tests/ft_r1_2_m_creator_orcid.rb
+++ b/lib/fair_tests/ft_r1_2_m_creator_orcid.rb
@@ -48,7 +48,7 @@ module FtR12MRorIdForFunder
         identifiers.each do |identifier|
           property_ids = schema_object_values(identifier, 'propertyID')
 
-          if (property_ids & %w[ORCID]).any? and identifier.include?('@ID') && con_ids.include?(identifier['@ID'])
+          if (property_ids & %w[ORCID]).any? && identifier.include?('@ID') && con_ids.include?(identifier['@ID'])
             pass = true
             break
           end

--- a/lib/fair_tests/ft_r1_2_m_creator_orcid.rb
+++ b/lib/fair_tests/ft_r1_2_m_creator_orcid.rb
@@ -1,0 +1,70 @@
+module FtR12MRorIdForFunder
+  require 'ftr_ruby'
+  require_relative '../fair_test_utils'
+  include FairTestUtils
+
+  def ft_r1_2_m_creator_orcid(url_record)
+    record = metadata_harvesting(url_record)
+
+    meta = {
+      testid: 'ft_r1_2_m_creator_orcid',
+      testname: 'FAIR Test - R1.2 - Metadata - Creator ORCIDs',
+      description: 'This test evaluates whether the metadata includes at least one qualified reference to ORCID for a contributor with a ‘creator’ role. The presence of ORCIDs linked to individuals, together with the defined ‘creator’ role, constitutes a qualified provenance reference. If the record contains a creator and this creator has an ORCID ID it will pass; otherwise, the test will fail.',
+      keywords: ['FAIR', 'R1.2', 'creator orcid'],
+      creator: 'https://orcid.org/0000-0002-6468-9260',
+      indicators: [],
+      metric: 'https://doi.org/10.25504/FAIRsharing.342aaa',
+      license: 'https://creativecommons.org/licenses/by/4.0/',
+      testversion: '1.0.0',
+      protocol: 'https',
+      host: 'fair-tests.fairsharing.org',
+      basePath: 'test'
+    }
+
+    response = FtrRuby::Output.new(
+      testedGUID: url_record,
+      meta: meta,
+      )
+
+    if record && !record.empty?
+      pass = false
+      identifiers = find_schema_property_value_triples(record)
+      creators = find_schema_object_values(record,'creator')
+      if identifiers.empty? || creators.empty?
+        response.score = 'fail'
+        response.comments << 'This record does not contain a creator with ORCID ID.'
+      else
+        con_ids = []
+        find_schema_object_values(creators,'@id').each do |id_c|
+          next unless id_c.is_a?(String)
+          find_all_schema_object_key_value(record, '@id', id_c).each do |c|
+            schema_object_values(c, 'identifier').each do |d|
+              con_ids << d[0]
+            end
+          end
+        end
+
+
+        identifiers.each do |identifier|
+          property_ids = schema_object_values(identifier, 'propertyID')
+
+          if (property_ids & %w[ORCID]).any? and identifier.include?('@ID') && con_ids.include?(identifier['@ID'])
+            pass = true
+            break
+          end
+        end
+
+        if pass
+          response.score = 'pass'
+          response.comments << 'This record contains ROR identifiers.'
+        else
+          response.score = 'fail'
+          response.comments << 'This record does not contain ROR identifiers.'
+        end
+      end
+    end
+
+    response.createEvaluationResponse
+
+  end
+end

--- a/public/test_descriptions/ft_r1_2_m_creator_orcid/api
+++ b/public/test_descriptions/ft_r1_2_m_creator_orcid/api
@@ -1,0 +1,38 @@
+openapi: 3.0.0
+info:
+  version: "1.0"
+  title: "FAIR Test - R1.2 - Metadata - Creator ORCIDs"
+  x-tests_metric: "https://doi.org/10.25504/FAIRsharing.342aaa"
+  description: >-
+      "This test evaluates whether the metadata includes at least one qualified reference to ORCID for a contributor with a ‘creator’ role. The presence of ORCIDs linked to individuals, together with the defined ‘creator’ role, constitutes a qualified provenance reference. If the record contains a creator and this creator has an ORCID ID it will pass; otherwise, the test will fail."
+  x-applies_to_principle: "https://doi.org/10.25504/FAIRsharing.3e9860"
+  contact:
+    x-organization: "FAIRsharing, Oxford University"
+    url: "https://fairsharing.org"
+    name: "FAIRsharing Support"
+    email: "contact@fairsharing.org"
+paths:
+  "/ft_r1_2_m_creator_orcid":
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/schemas"
+        required: true
+      responses:
+        "200":
+          description:  >-
+            The response is "pass", "fail" or "indeterminate"
+servers:
+  - url: "https://fair-tests.fairsharing.org/test"
+components:
+  schemas:
+    schemas:
+      required:
+        - resource_identifier
+      properties:
+      - resource_identifier:
+          type: string
+          description: the GUID being tested
+

--- a/test/fair_test_utils_test.rb
+++ b/test/fair_test_utils_test.rb
@@ -91,6 +91,62 @@ class FairTestUtilsTest < Minitest::Test
     assert_equal ['https://doi.org/10.1234/example'], schema_object_values(matches.first, 'url')
   end
 
+  def test_find_schema_object_values
+    data = {
+      '@graph' => [
+        {
+          '@id' => 'urn:local:harvester:graph',
+          'local:triples' => [
+            {
+              '@id' => [1, 2],
+              '@type' => ['http://schema.org/Dataset']
+            },
+            {
+              '@id' => '_:identifier',
+              '@type' => ['http://schema.org/PropertyValue'],
+              'http://schema.org/propertyID' => [{ '@value' => 'DOI' }],
+              'http://schema.org/url' => [{ '@id' => 'https://doi.org/10.1234/example' }]
+            }
+          ]
+        }
+      ]
+    }
+
+    matches = find_schema_object_values(data,'@id')
+
+    assert_equal 4, matches.length
+    assert_equal [1, 2], matches[1]
+    assert_equal 'https://doi.org/10.1234/example', matches[3]
+  end
+
+  def test_find_all_schema_object_key_value
+    data = {
+      '@graph' => [
+        {
+          '@id' => 'urn:local:harvester:graph',
+          'local:triples' => [
+            {
+              '@id' => [1, 2],
+              '@type' => ['http://schema.org/Dataset']
+            },
+            {
+              '@id' => '_:identifier',
+              '@type' => ['http://schema.org/PropertyValue'],
+              'http://schema.org/propertyID' => [{ '@value' => 'DOI' }],
+              'http://schema.org/url' => [{ '@id' => '_:identifier' }]
+            }
+          ]
+        }
+      ]
+    }
+
+    matches = find_all_schema_object_key_value(data,'@id', '_:identifier')
+
+    assert_equal 2, matches.length
+    assert_equal ['http://schema.org/PropertyValue'], matches[0]['@type']
+    assert_equal 1, matches[1].keys.length
+  end
+
   def test_jsonld_scalar_values_covers_supported_shapes
     assert_equal ['literal'], jsonld_scalar_values({ '@value' => 'literal' })
     assert_equal ['symbol literal'], jsonld_scalar_values({ :'@value' => 'symbol literal' })

--- a/test/ft_r1_2_m_creator_orcid_test.rb
+++ b/test/ft_r1_2_m_creator_orcid_test.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+require_relative './test_helper'
+require 'webmock/minitest'
+require_relative '../lib/fair_tests/ft_r1_2_m_creator_orcid'
+
+class FtR12MCreatorOrcidTest < Minitest::Test
+  include ::TestHelper
+  include ::FtR12MCreatorOrcid
+
+  def test_passes_when_schema_property_value_triple_creator_orcid
+    stub_metadata_harvesting(
+      {
+        '@graph' => [
+          {
+            '@id' => 'urn:local:harvester:graph',
+            'local:triples' => [
+              {
+                '@id' => 'uuid:example',
+                '@type' => ['http://schema.org/Dataset'],
+                "http://schema.org/creator"=>[{"@id"=>"_:g2763436033"}]
+              },
+              {"@id"=>"_:g2763436033",
+               "@type"=>["http://schema.org/Person"],
+               "http://schema.org/affiliation"=>[{"@id"=>"_:g27634380"}],
+               "http://schema.org/identifier"=>[{"@id"=>"_:g27634400"}],
+               "http://schema.org/name"=>[{"@value"=>"Smith, S"}]
+              },
+              {"@id"=>"_:g27634400",
+               "@type"=>["http://schema.org/PropertyValue"],
+               "http://schema.org/propertyID"=>[{"@value"=>"ORCID"}],
+               "http://schema.org/url"=>[{"@id"=>"https://orcid.org/0000-0002-2780-7819"}],
+               "http://schema.org/value"=>[{"@value"=>"0000-0002-2780-7819"}]
+              }
+            ]
+          }
+        ]
+      }
+    )
+
+    post '/test/ft_r1_2_m_creator_orcid',
+         params: { resource_identifier: 'https://example.org/records/abc123' }.to_json,
+         headers: headers
+
+    assert last_response.ok?
+
+    body = parsed_response_body(last_response.body)
+    assert_equal 'pass', find_prov_value(body)
+  end
+
+
+
+  def test_fails_when_no_schema_property_value_triples_exist
+    stub_metadata_harvesting(
+      {
+        '@graph' => [
+          {
+            '@id' => 'urn:local:harvester:graph',
+            'local:triples' => [
+              {
+                '@id' => 'uuid:example',
+                '@type' => ['http://schema.org/Dataset']
+              }
+            ]
+          }
+        ]
+      }
+    )
+
+    post '/test/ft_r1_2_m_creator_orcid',
+         params: { resource_identifier: 'https://example.org/records/abc123' }.to_json,
+         headers: headers
+
+    assert last_response.ok?
+
+    body = parsed_response_body(last_response.body)
+    assert_equal 'fail', find_prov_value(body)
+  end
+
+  def test_fails_when_schema_property_value_and_no_matched_orcid
+    stub_metadata_harvesting(
+      {
+        '@graph' => [
+          {
+            '@id' => 'urn:local:harvester:graph',
+            'local:triples' => [
+              {
+                '@id' => 'uuid:example',
+                '@type' => ['http://schema.org/Dataset'],
+                "http://schema.org/creator"=>[{"@id"=>"_:g2763436033"}]
+              },
+              {"@id"=>"_:g2763436033",
+               "@type"=>["http://schema.org/Person"],
+               "http://schema.org/affiliation"=>[{"@id"=>"_:g27634380"}],
+               "http://schema.org/identifier"=>[{"@id"=>"_:g27634400"}],
+               "http://schema.org/name"=>[{"@value"=>"Smith, S"}]
+              },
+              {"@id"=>"_:g276344001",
+               "@type"=>["http://schema.org/PropertyValue"],
+               "http://schema.org/propertyID"=>[{"@value"=>"ORCID"}],
+               "http://schema.org/url"=>[{"@id"=>"https://orcid.org/0000-0002-2780-7819"}],
+               "http://schema.org/value"=>[{"@value"=>"0000-0002-2780-7819"}]
+              }
+            ]
+          }
+        ]
+      }
+    )
+
+    post '/test/ft_r1_2_m_creator_orcid',
+         params: { resource_identifier: 'https://example.org/records/abc123' }.to_json,
+         headers: headers
+
+    assert last_response.ok?
+
+    body = parsed_response_body(last_response.body)
+    assert_equal 'fail', find_prov_value(body)
+  end
+end

--- a/test/ft_r1_2_m_ror_id_for_funder_test.rb
+++ b/test/ft_r1_2_m_ror_id_for_funder_test.rb
@@ -5,7 +5,7 @@ require_relative '../lib/fair_tests/ft_r1_2_m_ror_id_for_funder'
 
 class FtR12MRorIdForFunderTest < Minitest::Test
   include ::TestHelper
-  include ::FtF1MMetadataIdPersistent
+  include ::FtR12MRorIdForFunder
 
   def test_passes_when_schema_property_value_triple_contains_ror
     stub_metadata_harvesting(


### PR DESCRIPTION
This is for this #11 
An example of a test that works is:
require_relative './lib/fair_tests/ft_r1_2_m_creator_orcid.rb'; include FtR12MCreatorOrcid
d = ft_r1_2_m_creator_orcid('https://ora.ox.ac.uk/objects/uuid:520d21d2-bbcf-4a63-94f3-75dc2a015807')
(a creator with ORCID)

An example that does not work is:
 d = ft_r1_2_m_creator_orcid('https://ora.ox.ac.uk/objects/uuid:a013b30e-cec2-41a2-b2ef-a3b3b2985ffd')
(a creator without ORCID)
