### PR TITLE
Added an ora-only method for when the harvester is known to fail #9

### DIFF
--- a/lib/fair_test_utils.rb
+++ b/lib/fair_test_utils.rb
@@ -30,6 +30,23 @@ module FairTestUtils
     nil
   end
 
+  # Useful for getting records from ORA when the harvester is known to be unable to parse
+  # the fields required.
+  def request_jsonld(url)
+    json_headers = {
+      'Accept' => 'application/ld+json',
+      'Content-Type' => 'application/ld+json'
+    }
+    response = HTTParty.get(url, headers: json_headers)
+
+    body = response.body.to_s.strip
+    return nil if body.empty?
+
+    JSON.parse(body)
+  rescue JSON::ParserError
+    nil
+  end
+
   # Parse the data structure returned by metadata harvesting and look for particular keys.
   # Usage: has_matching_key_with_value?(data, %w[publisher publish])
   def has_matching_key_with_value?(obj, patterns)

--- a/lib/fair_tests/ft_i3_m_reference_research_objects.rb
+++ b/lib/fair_tests/ft_i3_m_reference_research_objects.rb
@@ -4,7 +4,13 @@ module FtI3MReferenceResearchObjects
   include FairTestUtils
 
   def ft_i3_m_reference_research_objects(url_record)
-    record = metadata_harvesting(url_record)
+    ora_format = false
+    if url_record.include? 'ora.ox.ac.uk'
+      record = request_jsonld(url_record)
+      ora_format = true
+    else
+      record = metadata_harvesting(url_record)
+    end
 
     meta = {
       testid: 'FT_I3_M_ReferenceResearchObjects.ttl',
@@ -26,17 +32,44 @@ module FtI3MReferenceResearchObjects
     response = FtrRuby::Output.new(
       testedGUID: url_record,
       meta: meta,
-      )
+    )
 
     if record && !record.empty?
       pass = false
-      isRelatedTo = find_schema_object_values(record, 'isRelatedTo')
-      if isRelatedTo.empty?
+
+      if ora_format
+        fieldName = 'isPartOf'
+      else
+        fieldName = 'isRelatedTo'
+      end
+
+      data = find_schema_object_values(record, fieldName)
+
+      if data.empty?
         response.score = 'fail'
         response.comments << 'This record does not contain references to related research objects.'
       else
-        pass = true unless isRelatedTo[0].empty?
+        if ora_format
+          # data will look like:
+          # [[{"@type" => "CreativeWork",
+          #    "name" => "The effect of ambient and injection pressure on droplet size of ammonia sprays in a constant volume chamber",
+          #    "url" => "/objects/uuid:7f161a34-1d6c-40aa-9539-847a4ff00f44"}]]
+          # pass should be true if there is at least one @type with a url value.
+          pass = data.flatten.any? do |related_object|
+            related_object.is_a?(Hash) &&
+              related_object['@type'].to_s.strip != '' &&
+              related_object['url'].to_s.strip != ''
+          end
+        else
+          # data will look like:
+          #  [[{"@id" => "_:g465680"}, {"@id" => "_:g464640"}]]
+          #  pass should be true if there is at least one @id with a value.
+          pass = data.flatten.any? do |related_object|
+            related_object.is_a?(Hash) && related_object['@id'].to_s.strip != ''
+          end
+        end
       end
+
       if pass
         response.score = 'pass'
         response.comments << 'This record contains references to related research objects.'

--- a/test/fair_test_utils_test.rb
+++ b/test/fair_test_utils_test.rb
@@ -45,6 +45,20 @@ class FairTestUtilsTest < Minitest::Test
     assert_nil metadata_harvesting("https://example.org/records/abc123")
   end
 
+  def test_request_jsonld_returns_parsed_json_or_nil
+    valid_url = "https://ora.ox.ac.uk/objects/uuid:valid"
+    empty_url = "https://ora.ox.ac.uk/objects/uuid:"
+    invalid_json_url = "https://ora.ox.ac.uk/objects/uuid:invalid"
+
+    stub_request_jsonld({ title: "This ORA record passes" }, resource_identifier: valid_url)
+    stub_request_jsonld("", resource_identifier: empty_url)
+    stub_request_jsonld("not json", resource_identifier: invalid_json_url)
+
+    assert_equal({ "title" => "This ORA record passes" }, request_jsonld(valid_url))
+    assert_nil request_jsonld(empty_url)
+    assert_nil request_jsonld(invalid_json_url)
+  end
+
   def test_contains_meaningful_value_covers_all_value_types
     refute contains_meaningful_value?(nil)
 

--- a/test/ft_i3_m_reference_research_objects_test.rb
+++ b/test/ft_i3_m_reference_research_objects_test.rb
@@ -8,6 +8,8 @@ class FtI3MReferenceResearchObjectsTest < Minitest::Test
   include ::TestHelper
   include ::FtI3MReferenceResearchObjects
 
+  ORA_RESOURCE_IDENTIFIER = 'https://ora.ox.ac.uk/objects/uuid:d7998de7-1c66-443b-9df7-b19dddd256b6'
+
   def test_passes_when_schema_reference_research_object
     stub_metadata_harvesting(
       {
@@ -49,7 +51,100 @@ class FtI3MReferenceResearchObjectsTest < Minitest::Test
     assert_equal 'pass', find_prov_value(body)
   end
 
+  def test_passes_when_ora_record_has_related_research_object
+    stub_request_jsonld(
+      {
+        '@context' => 'https://schema.org',
+        '@type' => 'Dataset',
+        'name' => 'Data supporting an ORA publication',
+        'isPartOf' => [
+          {
+            '@type' => 'CreativeWork',
+            'name' => 'The effect of ambient and injection pressure on droplet size of ammonia sprays',
+            'url' => '/objects/uuid:7f161a34-1d6c-40aa-9539-847a4ff00f44'
+          }
+        ]
+      }
+    )
 
+    post '/test/ft_i3_m_reference_research_objects',
+         params: { resource_identifier: ORA_RESOURCE_IDENTIFIER }.to_json,
+         headers: headers
+
+    assert last_response.ok?
+
+    body = parsed_response_body(last_response.body)
+    assert_equal 'pass', find_prov_value(body)
+  end
+
+  def test_fails_when_ora_record_has_no_related_research_object
+    stub_request_jsonld(
+      {
+        '@context' => 'https://schema.org',
+        '@type' => 'Dataset',
+        'name' => 'ORA record without related objects'
+      }
+    )
+
+    post '/test/ft_i3_m_reference_research_objects',
+         params: { resource_identifier: ORA_RESOURCE_IDENTIFIER }.to_json,
+         headers: headers
+
+    assert last_response.ok?
+
+    body = parsed_response_body(last_response.body)
+    assert_equal 'fail', find_prov_value(body)
+  end
+
+  def test_fails_when_ora_related_research_object_has_no_url
+    stub_request_jsonld(
+      {
+        '@context' => 'https://schema.org',
+        '@type' => 'Dataset',
+        'name' => 'ORA record with incomplete related objects',
+        'isPartOf' => [
+          {
+            '@type' => 'CreativeWork',
+            'name' => 'A related publication without a URL'
+          }
+        ]
+      }
+    )
+
+    post '/test/ft_i3_m_reference_research_objects',
+         params: { resource_identifier: ORA_RESOURCE_IDENTIFIER }.to_json,
+         headers: headers
+
+    assert last_response.ok?
+
+    body = parsed_response_body(last_response.body)
+    assert_equal 'fail', find_prov_value(body)
+  end
+
+  def test_fails_when_ora_related_research_object_has_no_type
+    stub_request_jsonld(
+      {
+        '@context' => 'https://schema.org',
+        '@type' => 'Dataset',
+        'name' => 'ORA record with incomplete related objects',
+        'isPartOf' => [
+          {
+            'name' => 'A related publication without a type',
+            'url' => '/objects/uuid:7f161a34-1d6c-40aa-9539-847a4ff00f44'
+          }
+        ]
+      }
+    )
+
+    post '/test/ft_i3_m_reference_research_objects',
+         params: { resource_identifier: ORA_RESOURCE_IDENTIFIER }.to_json,
+         headers: headers
+
+    assert last_response.ok?
+
+    body = parsed_response_body(last_response.body)
+    assert_equal 'fail', find_prov_value(body)
+  end
 
   def test_fails_when_no_reference_research_object
     stub_metadata_harvesting(

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -27,6 +27,7 @@ module TestHelper
     'Content-Type'=>'application/json',
     'User-Agent'=>'Ruby'
   }
+  ORA_RESOURCE_IDENTIFIER = "https://ora.ox.ac.uk/objects/uuid:d7998de7-1c66-443b-9df7-b19dddd256b6"
 
   def stub_metadata_harvesting(response_body, resource_identifier: "https://example.org/records/abc123")
     body = response_body.is_a?(String) ? response_body : response_body.to_json
@@ -35,6 +36,19 @@ module TestHelper
       with(
         body: { resource_identifier: resource_identifier }.to_json,
         headers: CHAMPION_HEADERS
+      ).
+      to_return(status: 200, body: body, headers: {})
+  end
+
+  def stub_request_jsonld(response_body, resource_identifier: ORA_RESOURCE_IDENTIFIER)
+    body = response_body.is_a?(String) ? response_body : response_body.to_json
+
+    stub_request(:get, resource_identifier).
+      with(
+        headers: {
+          'Accept' => 'application/ld+json',
+          'Content-Type' => 'application/ld+json'
+        }
       ).
       to_return(status: 200, body: body, headers: {})
   end


### PR DESCRIPTION
This should do a proper check for this field on ORA records.
I have added a generic method for requesting JSON+LD in case this is needed again. 